### PR TITLE
Highlighting Support for Solidity

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.sol linguist-language=Solidity


### PR DESCRIPTION
Adds in a `.gitattributes` file for solidity highlighting support.