### PR TITLE
update spec fixtures to match actual protocol

### DIFF
--- a/contracts/markettoken/mintable_functionality_test.go
+++ b/contracts/markettoken/mintable_functionality_test.go
@@ -27,8 +27,8 @@ func TestBalanceOf(t *testing.T) {
 		t.Errorf("Expected user balance of 0, got %v", userBal)
 	}
 
-	// owner has a truthy bal
-	ownerBal, _ := deployed.Contract.BalanceOf(&bind.CallOpts{From: context.AuthOwner.From}, context.AuthOwner.From)
+	// owner has a truthy bal. TODO this will change after we implement the "initial token table" later...
+	ownerBal, _ := deployed.Contract.BalanceOf(&bind.CallOpts{From: context.AuthFactory.From}, context.AuthFactory.From)
 
 	if ownerBal.Cmp(big.NewInt(0)) != 1 {
 		t.Errorf("Expected owner balance to be greater than 0, got %v", ownerBal)
@@ -43,7 +43,7 @@ func TestMint(t *testing.T) {
 	// the starting supply at this point
 	supply, _ := deployed.Contract.TotalSupply(nil)
 	// owner's current token holdings TODO this check may change?
-	ownerBal, _ := deployed.Contract.BalanceOf(&bind.CallOpts{From: context.AuthOwner.From}, context.AuthOwner.From)
+	ownerBal, _ := deployed.Contract.BalanceOf(&bind.CallOpts{From: context.AuthFactory.From}, context.AuthFactory.From)
 	marketBal, _ := deployed.Contract.BalanceOf(&bind.CallOpts{From: context.AuthMarket.From}, context.AuthMarket.From)
 
 	// minting will give market the minted amount and add to the total supply
@@ -75,7 +75,7 @@ func TestMint(t *testing.T) {
 	}
 
 	// total supply is increased but the balance of the initial holder did not - again, this may change TODO
-	ownerBalCheck, _ := deployed.Contract.BalanceOf(&bind.CallOpts{From: context.AuthOwner.From}, context.AuthOwner.From)
+	ownerBalCheck, _ := deployed.Contract.BalanceOf(&bind.CallOpts{From: context.AuthFactory.From}, context.AuthFactory.From)
 	if ownerBalCheck.Cmp(ownerBal) != 0 {
 		t.Errorf("Expected owner balance of %v, got %v", ownerBal, ownerBalCheck)
 	}
@@ -105,7 +105,7 @@ func TestStopMinting(t *testing.T) {
 
 	context.Blockchain.Commit()
 
-	if stopped, _ := deployed.Contract.MintingStopped(&bind.CallOpts{From: context.AuthOwner.From}); stopped != true {
+	if stopped, _ := deployed.Contract.MintingStopped(&bind.CallOpts{From: context.AuthFactory.From}); stopped != true {
 		t.Errorf("Expected minting stopped to be true, got %v", stopped)
 	}
 

--- a/contracts/networktoken/basic_functionality_test.go
+++ b/contracts/networktoken/basic_functionality_test.go
@@ -23,8 +23,8 @@ func TestTransfer(t *testing.T) {
 
 	// NOTE: if we want to view the transaction itself, it would be the first return arg
 	_, err := deployed.Contract.Transfer(&bind.TransactOpts{
-		From:     context.AuthOwner.From,
-		Signer:   context.AuthOwner.Signer,
+		From:     context.AuthFactory.From,
+		Signer:   context.AuthFactory.Signer,
 		Value:    nil,
 		GasPrice: big.NewInt(2000000000), //2 gwei
 		GasLimit: 100000,
@@ -50,7 +50,7 @@ func TestBalanceOf(t *testing.T) {
 	}
 
 	// that 100000 should have been subtracted from the original owner, Auth.From in this case
-	ownerBal, _ := deployed.Contract.BalanceOf(&bind.CallOpts{From: context.AuthOwner.From}, context.AuthOwner.From)
+	ownerBal, _ := deployed.Contract.BalanceOf(&bind.CallOpts{From: context.AuthFactory.From}, context.AuthFactory.From)
 
 	if ownerBal.Cmp(big.NewInt(900)) != 0 {
 		t.Errorf("Expected owner balance of 900, got %v", ownerBal)

--- a/contracts/networktoken/helpers.go
+++ b/contracts/networktoken/helpers.go
@@ -12,8 +12,8 @@ import (
 
 type ctx struct {
 	Alloc         core.GenesisAlloc // a map of accounts as { address: account }
-	AuthOwner     *bind.TransactOpts
-	AuthUser      *bind.TransactOpts
+	AuthFactory   *bind.TransactOpts
+	AuthMember    *bind.TransactOpts
 	Blockchain    *backends.SimulatedBackend
 	OtherUser     common.Address
 	OtherContract common.Address
@@ -28,9 +28,9 @@ type dep struct {
 func Deploy(initialBalance *big.Int, c *ctx) (*dep, error) {
 	// this method is generated in the burnable.go compiled sol class
 	addr, trans, cont, err := DeployNetworkToken(
-		c.AuthOwner,
+		c.AuthFactory,
 		c.Blockchain,
-		c.AuthOwner.From,
+		c.AuthFactory.From,
 		initialBalance,
 	)
 
@@ -46,20 +46,20 @@ func Deploy(initialBalance *big.Int, c *ctx) (*dep, error) {
 
 func SetupBlockchain(accountBalance *big.Int) *ctx {
 	// generate a new key, toss the error for now as it shouldnt happen
-	keyOwner, _ := crypto.GenerateKey()
-	authOwner := bind.NewKeyedTransactor(keyOwner)
-	keyUser, _ := crypto.GenerateKey()
-	authUser := bind.NewKeyedTransactor(keyUser)
+	keyFac, _ := crypto.GenerateKey()
+	authFac := bind.NewKeyedTransactor(keyFac)
+	keyMem, _ := crypto.GenerateKey()
+	authMem := bind.NewKeyedTransactor(keyMem)
 	alloc := make(core.GenesisAlloc)
-	alloc[authOwner.From] = core.GenesisAccount{Balance: accountBalance}
-	alloc[authUser.From] = core.GenesisAccount{Balance: accountBalance}
+	alloc[authFac.From] = core.GenesisAccount{Balance: accountBalance}
+	alloc[authMem.From] = core.GenesisAccount{Balance: accountBalance}
 	// 2nd arg is a gas limit, a uint64. we'll use 4.7M
 	bc := backends.NewSimulatedBackend(alloc, 4700000)
 
 	return &ctx{
 		Alloc:         alloc,
-		AuthOwner:     authOwner,
-		AuthUser:      authUser,
+		AuthFactory:   authFac,
+		AuthMember:    authMem,
 		Blockchain:    bc,
 		OtherUser:     common.HexToAddress("0xabc"),
 		OtherContract: common.HexToAddress("0xdef"),

--- a/contracts/networktoken/standard_functionality_test.go
+++ b/contracts/networktoken/standard_functionality_test.go
@@ -9,19 +9,19 @@ import (
 func TestTransferFrom(t *testing.T) {
 	t.Log("Network token should be able to transfer from one address to another")
 
-	ownerBal, _ := deployed.Contract.BalanceOf(&bind.CallOpts{From: context.AuthOwner.From}, context.AuthOwner.From)
+	ownerBal, _ := deployed.Contract.BalanceOf(&bind.CallOpts{From: context.AuthFactory.From}, context.AuthFactory.From)
 
 	// if we wanted to check the owner's account bal
-	// t.Logf("owner balance: %v", context.Alloc[context.AuthOwner.From].Balance)
+	// t.Logf("owner balance: %v", context.Alloc[context.AuthFactory.From].Balance)
 
 	// transfer from owner to user
 	_, err := deployed.Contract.Transfer(&bind.TransactOpts{
-		From:     context.AuthOwner.From,
-		Signer:   context.AuthOwner.Signer,
+		From:     context.AuthFactory.From,
+		Signer:   context.AuthFactory.Signer,
 		Value:    nil,
 		GasPrice: big.NewInt(2000000000), // 2 Gwei
 		GasLimit: 100000,
-	}, context.AuthUser.From, big.NewInt(10)) // 10 tokens
+	}, context.AuthMember.From, big.NewInt(10)) // 10 tokens
 
 	if err != nil {
 		t.Fatalf("Error transferring funds from owner to user: %v", err)
@@ -34,8 +34,8 @@ func TestTransferFrom(t *testing.T) {
 
 	// transfer from user to other user
 	_, err2 := deployed.Contract.Transfer(&bind.TransactOpts{
-		From:     context.AuthUser.From,
-		Signer:   context.AuthUser.Signer,
+		From:     context.AuthMember.From,
+		Signer:   context.AuthMember.Signer,
 		Value:    nil,
 		GasPrice: big.NewInt(2000000000), // 2 Gwei
 		GasLimit: 100000,
@@ -49,13 +49,13 @@ func TestTransferFrom(t *testing.T) {
 
 	// owner should have 10 subtracted
 	expectedBal := ownerBal.Sub(ownerBal, big.NewInt(10))
-	newOwnerBal, _ := deployed.Contract.BalanceOf(&bind.CallOpts{From: context.AuthOwner.From}, context.AuthOwner.From)
+	newOwnerBal, _ := deployed.Contract.BalanceOf(&bind.CallOpts{From: context.AuthFactory.From}, context.AuthFactory.From)
 	if newOwnerBal.Cmp(expectedBal) != 0 {
 		t.Errorf("Expected owner balance of %v, got %v", expectedBal, newOwnerBal)
 	}
 
 	// user should have had 5 subtracted from his 10
-	userBal, _ := deployed.Contract.BalanceOf(&bind.CallOpts{From: context.AuthUser.From}, context.AuthUser.From)
+	userBal, _ := deployed.Contract.BalanceOf(&bind.CallOpts{From: context.AuthMember.From}, context.AuthMember.From)
 	if userBal.Cmp(big.NewInt(5)) != 0 {
 		t.Errorf("Expected user balance of 5, got %v", userBal)
 	}
@@ -71,8 +71,8 @@ func TestApprove(t *testing.T) {
 	t.Log("Standard token should allow a user to approve a spender for some amount")
 
 	_, err := deployed.Contract.Approve(&bind.TransactOpts{
-		From:     context.AuthUser.From,
-		Signer:   context.AuthUser.Signer,
+		From:     context.AuthMember.From,
+		Signer:   context.AuthMember.Signer,
 		Value:    nil,
 		GasPrice: big.NewInt(2000000000), // 2 Gwei
 		GasLimit: 100000,
@@ -88,7 +88,7 @@ func TestApprove(t *testing.T) {
 func TestAllowance(t *testing.T) {
 	t.Log("Standard token should be able to check the spending allowance of a given address for a given user")
 
-	allowed, _ := deployed.Contract.Allowance(&bind.CallOpts{From: context.AuthUser.From}, context.AuthUser.From, context.OtherContract)
+	allowed, _ := deployed.Contract.Allowance(&bind.CallOpts{From: context.AuthMember.From}, context.AuthMember.From, context.OtherContract)
 	if allowed.Cmp(big.NewInt(4)) != 0 {
 		t.Errorf("Expected spender to be approved for 4, got %v", allowed)
 	}
@@ -98,8 +98,8 @@ func TestDecreaseApproval(t *testing.T) {
 	t.Log("Standard token should be able to decrease the spending allowance of a given address for a given user")
 
 	_, err := deployed.Contract.DecreaseApproval(&bind.TransactOpts{
-		From:     context.AuthUser.From,
-		Signer:   context.AuthUser.Signer,
+		From:     context.AuthMember.From,
+		Signer:   context.AuthMember.Signer,
 		Value:    nil,
 		GasPrice: big.NewInt(2000000000), // 2 Gwei
 		GasLimit: 100000,
@@ -111,7 +111,7 @@ func TestDecreaseApproval(t *testing.T) {
 
 	context.Blockchain.Commit()
 
-	allowed, _ := deployed.Contract.Allowance(&bind.CallOpts{From: context.AuthUser.From}, context.AuthUser.From, context.OtherContract)
+	allowed, _ := deployed.Contract.Allowance(&bind.CallOpts{From: context.AuthMember.From}, context.AuthMember.From, context.OtherContract)
 	if allowed.Cmp(big.NewInt(3)) != 0 {
 		t.Errorf("Expected spender to have been decreased to 3, got %v", allowed)
 	}
@@ -121,8 +121,8 @@ func TestIncreaseApproval(t *testing.T) {
 	t.Log("Standard token should be able to increase the spending allowance of a given address for a given user")
 
 	_, err := deployed.Contract.IncreaseApproval(&bind.TransactOpts{
-		From:     context.AuthUser.From,
-		Signer:   context.AuthUser.Signer,
+		From:     context.AuthMember.From,
+		Signer:   context.AuthMember.Signer,
 		Value:    nil,
 		GasPrice: big.NewInt(2000000000), // 2 Gwei
 		GasLimit: 100000,
@@ -134,7 +134,7 @@ func TestIncreaseApproval(t *testing.T) {
 
 	context.Blockchain.Commit()
 
-	allowed, _ := deployed.Contract.Allowance(&bind.CallOpts{From: context.AuthUser.From}, context.AuthUser.From, context.OtherContract)
+	allowed, _ := deployed.Contract.Allowance(&bind.CallOpts{From: context.AuthMember.From}, context.AuthMember.From, context.OtherContract)
 	if allowed.Cmp(big.NewInt(5)) != 0 {
 		t.Errorf("Expected spender to have been increased to 5, got %v", allowed)
 	}

--- a/contracts/parameterizer/deploy_parameterizer_test.go
+++ b/contracts/parameterizer/deploy_parameterizer_test.go
@@ -58,8 +58,8 @@ func TestMain(m *testing.M) {
 
 	// the voting contract must have its privileged addresk, NOTE this is done, IRL, by the factory
 	_, err := deployed.VotingContract.SetPrivilegedContracts(&bind.TransactOpts{
-		From:     context.AuthOwner.From,
-		Signer:   context.AuthOwner.Signer,
+		From:     context.AuthFactory.From,
+		Signer:   context.AuthFactory.Signer,
 		GasPrice: big.NewInt(2000000000),
 		GasLimit: 1000000,
 	}, context.AuthMarket.From, deployed.ParameterizerAddress)

--- a/contracts/parameterizer/helpers.go
+++ b/contracts/parameterizer/helpers.go
@@ -13,11 +13,11 @@ import (
 
 type ctx struct {
 	// 	Alloc          core.GenesisAlloc
-	AuthMarket     *bind.TransactOpts
-	AuthOwner      *bind.TransactOpts
-	AuthVoter      *bind.TransactOpts
-	AuthChallenger *bind.TransactOpts
-	Blockchain     *backends.SimulatedBackend
+	AuthMarket  *bind.TransactOpts
+	AuthFactory *bind.TransactOpts
+	AuthMember1 *bind.TransactOpts
+	AuthMember2 *bind.TransactOpts
+	Blockchain  *backends.SimulatedBackend
 }
 
 // NOTE: there is no marketAddress present as we don't need an actual market here
@@ -32,7 +32,7 @@ type dep struct {
 
 func Deploy(c *ctx) (*dep, error) {
 	votingAddr, votingTrans, votingCont, votingErr := voting.DeployVoting(
-		c.AuthOwner,
+		c.AuthFactory,
 		c.Blockchain,
 	)
 
@@ -43,7 +43,7 @@ func Deploy(c *ctx) (*dep, error) {
 	c.Blockchain.Commit()
 
 	paramAddr, paramTrans, paramCont, paramErr := DeployParameterizer(
-		c.AuthOwner,
+		c.AuthFactory,
 		c.Blockchain,
 		votingAddr,
 		big.NewInt(1000000000000000000), // challengeStake in tokenWei (10**18 == 1 token)
@@ -74,28 +74,28 @@ func Deploy(c *ctx) (*dep, error) {
 // parameterizer address is passed in
 func SetupBlockchain(accountBalance *big.Int) *ctx {
 	// generate a new key, toss the error for now as it shouldnt happen
-	keyMarket, _ := crypto.GenerateKey()
-	keyOwner, _ := crypto.GenerateKey()
-	keyChallenger, _ := crypto.GenerateKey()
-	keyVoter, _ := crypto.GenerateKey()
-	authMarket := bind.NewKeyedTransactor(keyMarket)
-	authOwner := bind.NewKeyedTransactor(keyOwner)
-	authChallenger := bind.NewKeyedTransactor(keyChallenger)
-	authVoter := bind.NewKeyedTransactor(keyVoter)
+	keyMark, _ := crypto.GenerateKey()
+	keyFac, _ := crypto.GenerateKey()
+	keyMem1, _ := crypto.GenerateKey()
+	keyMem2, _ := crypto.GenerateKey()
+	authMark := bind.NewKeyedTransactor(keyMark)
+	authFac := bind.NewKeyedTransactor(keyFac)
+	authMem1 := bind.NewKeyedTransactor(keyMem1)
+	authMem2 := bind.NewKeyedTransactor(keyMem2)
 	alloc := make(core.GenesisAlloc)
-	alloc[authMarket.From] = core.GenesisAccount{Balance: accountBalance}
-	alloc[authOwner.From] = core.GenesisAccount{Balance: accountBalance}
-	alloc[authChallenger.From] = core.GenesisAccount{Balance: accountBalance}
-	alloc[authVoter.From] = core.GenesisAccount{Balance: accountBalance}
+	alloc[authMark.From] = core.GenesisAccount{Balance: accountBalance}
+	alloc[authFac.From] = core.GenesisAccount{Balance: accountBalance}
+	alloc[authMem1.From] = core.GenesisAccount{Balance: accountBalance}
+	alloc[authMem2.From] = core.GenesisAccount{Balance: accountBalance}
 	// 2nd arg is a gas limit, a uint64. we'll use 4.7 million
 	bc := backends.NewSimulatedBackend(alloc, 4700000)
 
 	return &ctx{
 		// 	Alloc:          alloc,
-		AuthMarket:     authMarket,
-		AuthOwner:      authOwner,
-		AuthChallenger: authChallenger,
-		AuthVoter:      authVoter,
-		Blockchain:     bc,
+		AuthMarket:  authMark,
+		AuthFactory: authFac,
+		AuthMember1: authMem1,
+		AuthMember2: authMem2,
+		Blockchain:  bc,
 	}
 }

--- a/contracts/parameterizer/reparam_functionality_test.go
+++ b/contracts/parameterizer/reparam_functionality_test.go
@@ -17,7 +17,7 @@ func TestParameterize(t *testing.T) {
 		Signer:   context.AuthMarket.Signer,
 		GasPrice: big.NewInt(2000000000), // 2 Gwei
 		GasLimit: 100000,
-	}, context.AuthVoter.From)
+	}, context.AuthMember1.From)
 
 	if councilErr != nil {
 		t.Fatalf("Error adding council member: %v", councilErr)
@@ -26,8 +26,8 @@ func TestParameterize(t *testing.T) {
 	context.Blockchain.Commit()
 
 	_, err := deployed.ParameterizerContract.Reparameterize(&bind.TransactOpts{
-		From:     context.AuthVoter.From,
-		Signer:   context.AuthVoter.Signer,
+		From:     context.AuthMember1.From,
+		Signer:   context.AuthMember1.Signer,
 		GasPrice: big.NewInt(2000000000), // 2 Gwei
 		GasLimit: 200000,
 	}, "voteBy", big.NewInt(25))
@@ -50,8 +50,8 @@ func TestGetReparam(t *testing.T) {
 	paramHash, _ := deployed.ParameterizerContract.GetParamHash(nil, "voteBy", big.NewInt(25))
 	proposer, name, val, _ := deployed.ParameterizerContract.GetReparam(nil, paramHash)
 
-	if proposer != context.AuthVoter.From {
-		t.Fatalf("Expected proposer to be %v, got: %v", context.AuthVoter.From, proposer)
+	if proposer != context.AuthMember1.From {
+		t.Fatalf("Expected proposer to be %v, got: %v", context.AuthMember1.From, proposer)
 	}
 
 	if name != "voteBy" {
@@ -76,8 +76,8 @@ func TestResolveReparam(t *testing.T) {
 
 	// cast a vote, one will suffice as we only have one council member here
 	_, voteErr := deployed.VotingContract.Vote(&bind.TransactOpts{
-		From:     context.AuthVoter.From,
-		Signer:   context.AuthVoter.Signer,
+		From:     context.AuthMember1.From,
+		Signer:   context.AuthMember1.Signer,
 		GasPrice: big.NewInt(2000000000), // 2 Gwei
 		GasLimit: 100000,
 	}, paramHash)
@@ -101,8 +101,8 @@ func TestResolveReparam(t *testing.T) {
 
 	// resolve it
 	_, resolveErr := deployed.ParameterizerContract.ResolveReparam(&bind.TransactOpts{
-		From:     context.AuthVoter.From,
-		Signer:   context.AuthVoter.Signer,
+		From:     context.AuthMember1.From,
+		Signer:   context.AuthMember1.Signer,
 		GasPrice: big.NewInt(2000000000), // 2 Gwei
 		GasLimit: 150000,
 	}, paramHash)

--- a/contracts/voting/deploy_voting_test.go
+++ b/contracts/voting/deploy_voting_test.go
@@ -51,8 +51,8 @@ func TestMain(m *testing.M) {
 
 	// the voting contract must have its privileged addresses set or shit won't work, NOTE this is done, IRL, by the factory
 	_, err := deployed.VotingContract.SetPrivilegedContracts(&bind.TransactOpts{
-		From:     context.AuthOwner.From,
-		Signer:   context.AuthOwner.Signer,
+		From:     context.AuthFactory.From,
+		Signer:   context.AuthFactory.Signer,
 		GasPrice: big.NewInt(2000000000),
 		GasLimit: 1000000,
 	}, context.AuthMarket.From, context.AuthParameterizer.From)

--- a/contracts/voting/helpers.go
+++ b/contracts/voting/helpers.go
@@ -12,10 +12,10 @@ import (
 
 type ctx struct {
 	AuthMarket        *bind.TransactOpts
-	AuthOwner         *bind.TransactOpts
+	AuthFactory       *bind.TransactOpts
 	AuthParameterizer *bind.TransactOpts
-	AuthVoter         *bind.TransactOpts
-	AuthChallenger    *bind.TransactOpts
+	AuthMember1       *bind.TransactOpts
+	AuthMember2       *bind.TransactOpts
 	Blockchain        *backends.SimulatedBackend
 }
 
@@ -27,7 +27,7 @@ type dep struct {
 
 func Deploy(c *ctx) (*dep, error) {
 	votingAddr, votingTrans, votingCont, votingErr := DeployVoting(
-		c.AuthOwner,
+		c.AuthFactory,
 		c.Blockchain,
 	)
 
@@ -53,31 +53,31 @@ func genBytes32(name string) [32]byte {
 
 func SetupBlockchain(accountBalance *big.Int) *ctx {
 	// generate a new key, toss the error for now as it shouldnt happen
-	keyMarket, _ := crypto.GenerateKey()
-	keyOwner, _ := crypto.GenerateKey()
-	keyParameterizer, _ := crypto.GenerateKey()
-	keyChallenger, _ := crypto.GenerateKey()
-	keyVoter, _ := crypto.GenerateKey()
-	authMarket := bind.NewKeyedTransactor(keyMarket)
-	authOwner := bind.NewKeyedTransactor(keyOwner)
-	authParameterizer := bind.NewKeyedTransactor(keyParameterizer)
-	authChallenger := bind.NewKeyedTransactor(keyChallenger)
-	authVoter := bind.NewKeyedTransactor(keyVoter)
+	keyMark, _ := crypto.GenerateKey()
+	keyFac, _ := crypto.GenerateKey()
+	keyParam, _ := crypto.GenerateKey()
+	keyMem1, _ := crypto.GenerateKey()
+	keyMem2, _ := crypto.GenerateKey()
+	authMark := bind.NewKeyedTransactor(keyMark)
+	authFac := bind.NewKeyedTransactor(keyFac)
+	authParam := bind.NewKeyedTransactor(keyParam)
+	authMem1 := bind.NewKeyedTransactor(keyMem1)
+	authMem2 := bind.NewKeyedTransactor(keyMem2)
 	alloc := make(core.GenesisAlloc)
-	alloc[authMarket.From] = core.GenesisAccount{Balance: accountBalance}
-	alloc[authOwner.From] = core.GenesisAccount{Balance: accountBalance}
-	alloc[authParameterizer.From] = core.GenesisAccount{Balance: accountBalance}
-	alloc[authChallenger.From] = core.GenesisAccount{Balance: accountBalance}
-	alloc[authVoter.From] = core.GenesisAccount{Balance: accountBalance}
+	alloc[authMark.From] = core.GenesisAccount{Balance: accountBalance}
+	alloc[authFac.From] = core.GenesisAccount{Balance: accountBalance}
+	alloc[authParam.From] = core.GenesisAccount{Balance: accountBalance}
+	alloc[authMem1.From] = core.GenesisAccount{Balance: accountBalance}
+	alloc[authMem2.From] = core.GenesisAccount{Balance: accountBalance}
 	// 2nd arg is a gas limit, a uint64. we'll use 4.7 million
 	bc := backends.NewSimulatedBackend(alloc, 4700000)
 
 	return &ctx{
-		AuthMarket:        authMarket,
-		AuthOwner:         authOwner,
-		AuthParameterizer: authParameterizer,
-		AuthChallenger:    authChallenger,
-		AuthVoter:         authVoter, // a councilmember
+		AuthMarket:        authMark,
+		AuthFactory:       authFac,
+		AuthParameterizer: authParam,
+		AuthMember1:       authMem1,
+		AuthMember2:       authMem2, // a councilmember
 		Blockchain:        bc,
 	}
 }

--- a/contracts/voting/voting_functionality_test.go
+++ b/contracts/voting/voting_functionality_test.go
@@ -16,7 +16,7 @@ func TestVote(t *testing.T) {
 		Signer:   context.AuthMarket.Signer,
 		GasPrice: big.NewInt(2000000000), // 2 Gwei
 		GasLimit: 100000,
-	}, context.AuthVoter.From)
+	}, context.AuthMember1.From)
 
 	if councilErr != nil {
 		t.Fatalf("Error adding council member: %v", councilErr)
@@ -40,8 +40,8 @@ func TestVote(t *testing.T) {
 
 	// cast a vote
 	_, voteErr := deployed.VotingContract.Vote(&bind.TransactOpts{
-		From:     context.AuthVoter.From,
-		Signer:   context.AuthVoter.Signer,
+		From:     context.AuthMember1.From,
+		Signer:   context.AuthMember1.Signer,
 		GasPrice: big.NewInt(2000000000), // 2 Gwei
 		GasLimit: 100000,
 	}, bytes)
@@ -64,7 +64,7 @@ func TestDidVote(t *testing.T) {
 	t.Log("Voting contract has recorded that a member cast a vote")
 
 	bytes := genBytes32("iLoveListing.com")
-	voted, _ := deployed.VotingContract.DidVote(nil, bytes, context.AuthVoter.From)
+	voted, _ := deployed.VotingContract.DidVote(nil, bytes, context.AuthMember1.From)
 
 	if voted != true {
 		t.Fatalf("Expected member didVote to be true, got: %v", voted)


### PR DESCRIPTION
broke this out on its own to prevent PR sprawl.

changes the old TCR verbage around test fixtures (owner, voter, challenger) to our market verbage (factory, member1, member2)