### PR TITLE
Scenario Test for creator block size of 0 and no reserve investment

### DIFF
--- a/tests/creatorblocktest/scenariofive/deploy_scenario_five_test.go
+++ b/tests/creatorblocktest/scenariofive/deploy_scenario_five_test.go
@@ -90,15 +90,15 @@ func TestMain(m *testing.M) {
 	context.Blockchain = backends.NewSimulatedBackend(context.Alloc, 4700000)
 
 	deployed, deployedError = test.Deploy(oneHundredOneEth, big.NewInt(test.ONE_ETH), context, &test.Params{
-		ConversionRate: big.NewInt(test.ONE_MWEI),
-		Spread:         big.NewInt(110),
-		ListReward:     big.NewInt(250000000000000),   // 2.5 x 10**13
-		Stake:          big.NewInt(10000000000000000), // 1 X 10**16
-		VoteBy:         big.NewInt(100),
-		Quorum:         big.NewInt(50),
-		BackendPct:     big.NewInt(25),
-		MakerPct:       big.NewInt(50),
-		CostPerByte:    big.NewInt(test.ONE_GWEI * 100),
+		PriceFloor:  big.NewInt(test.ONE_MWEI),
+		Spread:      big.NewInt(110),
+		ListReward:  big.NewInt(250000000000000),   // 2.5 x 10**13
+		Stake:       big.NewInt(10000000000000000), // 1 X 10**16
+		VoteBy:      big.NewInt(100),
+		Quorum:      big.NewInt(50),
+		BackendPct:  big.NewInt(25),
+		MakerPct:    big.NewInt(50),
+		CostPerByte: big.NewInt(test.ONE_GWEI * 100),
 	})
 
 	// setup the datatrust with a backend

--- a/tests/creatorblocktest/scenariofive/deploy_scenario_five_test.go
+++ b/tests/creatorblocktest/scenariofive/deploy_scenario_five_test.go
@@ -95,7 +95,7 @@ func TestMain(m *testing.M) {
 		ListReward:  big.NewInt(250000000000000),   // 2.5 x 10**13
 		Stake:       big.NewInt(10000000000000000), // 1 X 10**16
 		VoteBy:      big.NewInt(100),
-		Quorum:      big.NewInt(50),
+		Plurality:   big.NewInt(50),
 		BackendPct:  big.NewInt(25),
 		MakerPct:    big.NewInt(50),
 		CostPerByte: big.NewInt(test.ONE_GWEI * 100),

--- a/tests/creatorblocktest/scenariofour/deploy_scenario_four_test.go
+++ b/tests/creatorblocktest/scenariofour/deploy_scenario_four_test.go
@@ -61,7 +61,7 @@ func TestMain(m *testing.M) {
 		ListReward:  big.NewInt(250000000000000),   // 2.5 x 10**13
 		Stake:       big.NewInt(10000000000000000), // 1 X 10**16
 		VoteBy:      big.NewInt(100),
-		Quorum:      big.NewInt(50),
+		Plurality:   big.NewInt(50),
 		BackendPct:  big.NewInt(25),
 		MakerPct:    big.NewInt(25),
 		CostPerByte: big.NewInt(test.ONE_GWEI * 100),

--- a/tests/creatorblocktest/scenariofour/deploy_scenario_four_test.go
+++ b/tests/creatorblocktest/scenariofour/deploy_scenario_four_test.go
@@ -56,15 +56,15 @@ func TestMain(m *testing.M) {
 	context.Blockchain = backends.NewSimulatedBackend(context.Alloc, 4700000)
 
 	deployed, deployedError = test.Deploy(oneHundredOneEth, big.NewInt(test.ONE_ETH), context, &test.Params{
-		ConversionRate: big.NewInt(test.ONE_MWEI),
-		Spread:         big.NewInt(110),
-		ListReward:     big.NewInt(250000000000000),   // 2.5 x 10**13
-		Stake:          big.NewInt(10000000000000000), // 1 X 10**16
-		VoteBy:         big.NewInt(100),
-		Quorum:         big.NewInt(50),
-		BackendPct:     big.NewInt(25),
-		MakerPct:       big.NewInt(25),
-		CostPerByte:    big.NewInt(test.ONE_GWEI * 100),
+		PriceFloor:  big.NewInt(test.ONE_MWEI),
+		Spread:      big.NewInt(110),
+		ListReward:  big.NewInt(250000000000000),   // 2.5 x 10**13
+		Stake:       big.NewInt(10000000000000000), // 1 X 10**16
+		VoteBy:      big.NewInt(100),
+		Quorum:      big.NewInt(50),
+		BackendPct:  big.NewInt(25),
+		MakerPct:    big.NewInt(25),
+		CostPerByte: big.NewInt(test.ONE_GWEI * 100),
 	})
 
 	// setup the datatrust with a backend

--- a/tests/creatorblocktest/scenarioone/deploy_scenario_one_test.go
+++ b/tests/creatorblocktest/scenarioone/deploy_scenario_one_test.go
@@ -23,15 +23,15 @@ func TestMain(m *testing.M) {
 	// etherToken bal, marketToken bal, ctx, params (args)
 	deployed, deployedError = test.Deploy(oneHundredOneEth, big.NewInt(test.ONE_ETH),
 		context, &test.Params{
-			ConversionRate: big.NewInt(test.ONE_MWEI),
-			Spread:         big.NewInt(110),
-			ListReward:     big.NewInt(250000000000000),   // 2.5 x 10**13
-			Stake:          big.NewInt(10000000000000000), // 1 X 10**16
-			VoteBy:         big.NewInt(100),               // no need to use a "real" voteBy
-			Quorum:         big.NewInt(50),
-			BackendPct:     big.NewInt(25),
-			MakerPct:       big.NewInt(25),
-			CostPerByte:    big.NewInt(test.ONE_GWEI * 100),
+			PriceFloor:  big.NewInt(test.ONE_MWEI),
+			Spread:      big.NewInt(110),
+			ListReward:  big.NewInt(250000000000000),   // 2.5 x 10**13
+			Stake:       big.NewInt(10000000000000000), // 1 X 10**16
+			VoteBy:      big.NewInt(100),               // no need to use a "real" voteBy
+			Quorum:      big.NewInt(50),
+			BackendPct:  big.NewInt(25),
+			MakerPct:    big.NewInt(25),
+			CostPerByte: big.NewInt(test.ONE_GWEI * 100),
 		})
 
 	code := m.Run()

--- a/tests/creatorblocktest/scenarioone/deploy_scenario_one_test.go
+++ b/tests/creatorblocktest/scenarioone/deploy_scenario_one_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 			ListReward:  big.NewInt(250000000000000),   // 2.5 x 10**13
 			Stake:       big.NewInt(10000000000000000), // 1 X 10**16
 			VoteBy:      big.NewInt(100),               // no need to use a "real" voteBy
-			Quorum:      big.NewInt(50),
+			Plurality:   big.NewInt(50),
 			BackendPct:  big.NewInt(25),
 			MakerPct:    big.NewInt(25),
 			CostPerByte: big.NewInt(test.ONE_GWEI * 100),

--- a/tests/creatorblocktest/scenariosix/deploy_scenario_six_test.go
+++ b/tests/creatorblocktest/scenariosix/deploy_scenario_six_test.go
@@ -62,7 +62,7 @@ func TestMain(m *testing.M) {
 			ListReward:  big.NewInt(250000000000000),   // 2.5 x 10**13
 			Stake:       big.NewInt(10000000000000000), // 1 X 10**16
 			VoteBy:      big.NewInt(100),               // no need to use a "real" voteBy
-			Quorum:      big.NewInt(50),
+			Plurality:   big.NewInt(50),
 			BackendPct:  big.NewInt(25),
 			MakerPct:    big.NewInt(25),
 			CostPerByte: big.NewInt(test.ONE_GWEI * 100),

--- a/tests/creatorblocktest/scenariosix/deploy_scenario_six_test.go
+++ b/tests/creatorblocktest/scenariosix/deploy_scenario_six_test.go
@@ -1,4 +1,4 @@
-package scenariothree
+package scenariosix
 
 import (
 	"fmt"
@@ -45,16 +45,17 @@ func setupSupporters(bal *big.Int, numSupporters int) {
 func TestMain(m *testing.M) {
 	// need this to create bigger ETH balances (literal will overflow)
 	var x big.Int
+	zeroEth := big.NewInt(0)
 	oneHundredEth := x.Mul(big.NewInt(test.ONE_ETH), big.NewInt(100))
 	oneHundredOneEth := x.Add(oneHundredEth, big.NewInt(test.ONE_ETH))
 
 	context = test.GetContext(oneHundredOneEth) // users have 101 ETH account bal
-	setupSupporters(oneHundredOneEth, 20)       // supporters have 101 ETH account balance
+	setupSupporters(oneHundredOneEth, 10)       // supporters have 101 ETH account balance
 
 	// override the original simulated backend now that we have appeneded to the allocation
 	context.Blockchain = backends.NewSimulatedBackend(context.Alloc, 4700000)
 
-	deployed, deployedError = test.Deploy(oneHundredOneEth, big.NewInt(test.ONE_ETH),
+	deployed, deployedError = test.Deploy(oneHundredOneEth, zeroEth,
 		context, &test.Params{
 			PriceFloor:  big.NewInt(test.ONE_MWEI),
 			Spread:      big.NewInt(110),

--- a/tests/creatorblocktest/scenariosix/scenario_six_test.go
+++ b/tests/creatorblocktest/scenariosix/scenario_six_test.go
@@ -5,7 +5,6 @@ import (
 	"github.com/computablelabs/goest/tests/test"
 	"math/big"
 	"testing"
-	//"time"
 )
 
 func oneHundredOneEth() *big.Int {

--- a/tests/creatorblocktest/scenariosix/scenario_six_test.go
+++ b/tests/creatorblocktest/scenariosix/scenario_six_test.go
@@ -1,0 +1,115 @@
+package scenariosix
+
+import (
+	"fmt"
+	"github.com/computablelabs/goest/tests/test"
+	"math/big"
+	"testing"
+	//"time"
+)
+
+func oneHundredOneEth() *big.Int {
+	one := big.NewInt(test.ONE_ETH)
+	oneHundred := one.Mul(one, big.NewInt(100))
+	return oneHundred.Add(oneHundred, big.NewInt(test.ONE_ETH))
+}
+
+func oneHundredEth() *big.Int {
+	one := big.NewInt(test.ONE_ETH)
+	return one.Mul(one, big.NewInt(100))
+}
+
+func zeroEth() *big.Int {
+	return big.NewInt(0)
+}
+
+func TestInitialBalance(t *testing.T) {
+	// owner has all the eth atm
+	etBal, _ := deployed.EtherTokenContract.BalanceOf(nil, context.AuthOwner.From)
+	// all market tokens that exist atm
+	mtSup, _ := deployed.MarketTokenContract.TotalSupply(nil)
+	if etBal.Cmp(oneHundredOneEth()) != 0 {
+		t.Errorf("Expected ether token balance of %v, got: %v", oneHundredOneEth(), etBal)
+	}
+	if mtSup.Cmp(big.NewInt(0)) != 0 {
+		t.Errorf("Expected market token supply of 1 wei, got: %v", mtSup)
+	}
+
+	t.Logf("Current Market Token total supply: %v", test.Commafy(mtSup))
+}
+
+// This differs from test in scenario-two since it has more supporters
+func TestTransferToReserveThenSupport(t *testing.T) {
+
+	//ownerEthBal, _ := deployed.EtherTokenContract.BalanceOf(nil, context.AuthOwner.From)
+	resEthBal, _ := deployed.EtherTokenContract.BalanceOf(nil, deployed.ReserveAddress)
+
+	// got the 100
+	if resEthBal.Cmp(zeroEth()) != 0 {
+		t.Errorf("Expected reserve of 100 Eth, got: %v", resEthBal)
+	}
+
+	t.Logf("Current Reserve balance: %v", test.Commafy(resEthBal))
+	t.Logf("Number supporters: %d", len(supporters))
+
+	//for name, supporter := range supporters {
+	for name, supporter := range supporters {
+
+		etBal, _ := deployed.EtherTokenContract.BalanceOf(nil, supporter.From)
+		if etBal.Cmp(big.NewInt(0)) != 0 {
+			t.Errorf("Expected ether token balance of 0, got: %v", etBal)
+		}
+		_, depErr := deployed.EtherTokenContract.Deposit(test.GetTxOpts(supporter,
+			oneHundredEth(), big.NewInt(test.ONE_GWEI*2), 100000))
+		test.IfNotNil(t, depErr, "Error depositing ETH")
+		context.Blockchain.Commit()
+
+		//	// snapshot current balances
+		etBalNow, _ := deployed.EtherTokenContract.BalanceOf(nil, supporter.From)
+		if etBalNow.Cmp(oneHundredEth()) != 0 {
+			t.Errorf("Expected ether token balance of 100 eth, got: %v", etBalNow)
+		}
+		mtBal, _ := deployed.MarketTokenContract.BalanceOf(nil, supporter.From)
+		if mtBal.Cmp(big.NewInt(0)) != 0 {
+			t.Errorf("Expected market token balance of 0, got: %v", mtBal)
+		}
+		t.Logf("%s current market token balance: %v", name, mtBal)
+
+		sPrice, _ := deployed.ReserveContract.GetSupportPrice(nil)
+		t.Logf("Current support price: %v", test.Commafy(sPrice))
+
+		_, approveErr := deployed.EtherTokenContract.Approve(test.GetTxOpts(supporter, nil,
+			big.NewInt(test.ONE_GWEI*2), 100000), deployed.ReserveAddress, oneHundredEth()) // up to 100 ETH
+		test.IfNotNil(t, approveErr, fmt.Sprintf("Error approving market contract to spend: %v", approveErr))
+		context.Blockchain.Commit()
+
+		allowed, _ := deployed.EtherTokenContract.Allowance(nil, supporter.From, deployed.ReserveAddress)
+		if allowed.Cmp(oneHundredEth()) != 0 {
+			t.Errorf("Expected allowance of 100 ETH, got: %v", allowed)
+		}
+
+		_, sErr := deployed.ReserveContract.Support(test.GetTxOpts(supporter, nil,
+			big.NewInt(test.ONE_GWEI*2), 150000), oneHundredEth())
+		test.IfNotNil(t, sErr, "Error supporting")
+		context.Blockchain.Commit()
+
+		// check current market token balance
+		mtBalNow, _ := deployed.MarketTokenContract.BalanceOf(nil, supporter.From)
+		if mtBalNow.Cmp(mtBal) != 1 {
+			t.Errorf("Expected %v to be > %v", mtBalNow, mtBal)
+		}
+		t.Logf("%s market token balance post 100 ETH support: %v", name, test.Commafy(mtBalNow))
+
+		// market token total supply should be updated
+		mtSup, _ := deployed.MarketTokenContract.TotalSupply(nil)
+		t.Logf("Market token total supply post %s support of 100 ETH: %v", name, test.Commafy(mtSup))
+
+		// Get new reserve balance
+		resEthBal, _ = deployed.EtherTokenContract.BalanceOf(nil, deployed.ReserveAddress)
+		// reserve should be updated
+		t.Logf("Reserve balance post %s support of 100 ETH: %v", name, test.Commafy(resEthBal))
+
+		sPriceNow, _ := deployed.ReserveContract.GetSupportPrice(nil)
+		t.Logf("Support Price post %s support of 100 ETH: %v", name, test.Commafy(sPriceNow))
+	}
+}

--- a/tests/creatorblocktest/scenariothree/deploy_scenario_three_test.go
+++ b/tests/creatorblocktest/scenariothree/deploy_scenario_three_test.go
@@ -61,7 +61,7 @@ func TestMain(m *testing.M) {
 			ListReward:  big.NewInt(250000000000000),   // 2.5 x 10**13
 			Stake:       big.NewInt(10000000000000000), // 1 X 10**16
 			VoteBy:      big.NewInt(100),               // no need to use a "real" voteBy
-			Quorum:      big.NewInt(50),
+			Plurality:   big.NewInt(50),
 			BackendPct:  big.NewInt(25),
 			MakerPct:    big.NewInt(25),
 			CostPerByte: big.NewInt(test.ONE_GWEI * 100),

--- a/tests/creatorblocktest/scenariotwo/deploy_scenario_two_test.go
+++ b/tests/creatorblocktest/scenariotwo/deploy_scenario_two_test.go
@@ -27,7 +27,7 @@ func TestMain(m *testing.M) {
 			ListReward:  big.NewInt(250000000000000),   // 2.5 x 10**13
 			Stake:       big.NewInt(10000000000000000), // 1 X 10**16
 			VoteBy:      big.NewInt(100),               // no need to use a "real" voteBy
-			Quorum:      big.NewInt(50),
+			Plurality:   big.NewInt(50),
 			BackendPct:  big.NewInt(25),
 			MakerPct:    big.NewInt(25),
 			CostPerByte: big.NewInt(test.ONE_GWEI * 100),

--- a/tests/creatorblocktest/scenariotwo/deploy_scenario_two_test.go
+++ b/tests/creatorblocktest/scenariotwo/deploy_scenario_two_test.go
@@ -22,15 +22,15 @@ func TestMain(m *testing.M) {
 	// etherToken bal, marketToken bal, ctx, params (args)
 	deployed, deployedError = test.Deploy(oneHundredOneEth, big.NewInt(test.ONE_ETH),
 		context, &test.Params{
-			ConversionRate: big.NewInt(test.ONE_SZABO),
-			Spread:         big.NewInt(110),
-			ListReward:     big.NewInt(250000000000000),   // 2.5 x 10**13
-			Stake:          big.NewInt(10000000000000000), // 1 X 10**16
-			VoteBy:         big.NewInt(100),               // no need to use a "real" voteBy
-			Quorum:         big.NewInt(50),
-			BackendPct:     big.NewInt(25),
-			MakerPct:       big.NewInt(25),
-			CostPerByte:    big.NewInt(test.ONE_GWEI * 100),
+			PriceFloor:  big.NewInt(test.ONE_SZABO),
+			Spread:      big.NewInt(110),
+			ListReward:  big.NewInt(250000000000000),   // 2.5 x 10**13
+			Stake:       big.NewInt(10000000000000000), // 1 X 10**16
+			VoteBy:      big.NewInt(100),               // no need to use a "real" voteBy
+			Quorum:      big.NewInt(50),
+			BackendPct:  big.NewInt(25),
+			MakerPct:    big.NewInt(25),
+			CostPerByte: big.NewInt(test.ONE_GWEI * 100),
 		})
 
 	code := m.Run()

--- a/tests/datatrusttest/deploy_datatrust_test.go
+++ b/tests/datatrusttest/deploy_datatrust_test.go
@@ -46,7 +46,7 @@ func TestMain(m *testing.M) {
 		ListReward:  big.NewInt(test.ONE_ETH),
 		Stake:       big.NewInt(test.ONE_GWEI),
 		VoteBy:      big.NewInt(100),
-		Quorum:      big.NewInt(50),
+		Plurality:   big.NewInt(50),
 		BackendPct:  big.NewInt(25),
 		MakerPct:    big.NewInt(50),
 		CostPerByte: big.NewInt(test.ONE_KWEI * 6),

--- a/tests/datatrusttest/deploy_datatrust_test.go
+++ b/tests/datatrusttest/deploy_datatrust_test.go
@@ -41,15 +41,15 @@ func TestDatatrustGetReserve(t *testing.T) {
 func TestMain(m *testing.M) {
 	context = test.GetContext(big.NewInt(test.ONE_ETH * 3)) // users have 3 ETH
 	deployed, deployedError = test.Deploy(big.NewInt(test.ONE_ETH*6), big.NewInt(test.ONE_ETH*6), context, &test.Params{
-		ConversionRate: big.NewInt(test.ONE_GWEI),
-		Spread:         big.NewInt(110),
-		ListReward:     big.NewInt(test.ONE_ETH),
-		Stake:          big.NewInt(test.ONE_GWEI),
-		VoteBy:         big.NewInt(100),
-		Quorum:         big.NewInt(50),
-		BackendPct:     big.NewInt(25),
-		MakerPct:       big.NewInt(50),
-		CostPerByte:    big.NewInt(test.ONE_KWEI * 6),
+		PriceFloor:  big.NewInt(test.ONE_GWEI),
+		Spread:      big.NewInt(110),
+		ListReward:  big.NewInt(test.ONE_ETH),
+		Stake:       big.NewInt(test.ONE_GWEI),
+		VoteBy:      big.NewInt(100),
+		Quorum:      big.NewInt(50),
+		BackendPct:  big.NewInt(25),
+		MakerPct:    big.NewInt(50),
+		CostPerByte: big.NewInt(test.ONE_KWEI * 6),
 	})
 	code := m.Run()
 	os.Exit(code)

--- a/tests/dustingtest/deploy_dusting_test.go
+++ b/tests/dustingtest/deploy_dusting_test.go
@@ -16,15 +16,15 @@ func TestMain(m *testing.M) {
 	// etherToken bal, marketToken bal, ctx, params (args)
 	deployed, deployedError = test.Deploy(big.NewInt(test.ONE_ETH*9), big.NewInt(test.ONE_ETH*9),
 		context, &test.Params{
-			ConversionRate: big.NewInt(test.ONE_SZABO),
-			Spread:         big.NewInt(110),
-			ListReward:     big.NewInt(250000000000000),   // 2.5 x 10**13
-			Stake:          big.NewInt(10000000000000000), // 1 X 10**16
-			VoteBy:         big.NewInt(100),               // no need to use a "real" voteBy
-			Quorum:         big.NewInt(50),
-			BackendPct:     big.NewInt(39),
-			MakerPct:       big.NewInt(21),
-			CostPerByte:    big.NewInt(test.ONE_GWEI * 100),
+			PriceFloor:  big.NewInt(test.ONE_SZABO),
+			Spread:      big.NewInt(110),
+			ListReward:  big.NewInt(250000000000000),   // 2.5 x 10**13
+			Stake:       big.NewInt(10000000000000000), // 1 X 10**16
+			VoteBy:      big.NewInt(100),               // no need to use a "real" voteBy
+			Quorum:      big.NewInt(50),
+			BackendPct:  big.NewInt(39),
+			MakerPct:    big.NewInt(21),
+			CostPerByte: big.NewInt(test.ONE_GWEI * 100),
 		})
 
 	code := m.Run()

--- a/tests/dustingtest/deploy_dusting_test.go
+++ b/tests/dustingtest/deploy_dusting_test.go
@@ -21,7 +21,7 @@ func TestMain(m *testing.M) {
 			ListReward:  big.NewInt(250000000000000),   // 2.5 x 10**13
 			Stake:       big.NewInt(10000000000000000), // 1 X 10**16
 			VoteBy:      big.NewInt(100),               // no need to use a "real" voteBy
-			Quorum:      big.NewInt(50),
+			Plurality:   big.NewInt(50),
 			BackendPct:  big.NewInt(39),
 			MakerPct:    big.NewInt(21),
 			CostPerByte: big.NewInt(test.ONE_GWEI * 100),

--- a/tests/ethertokentest/deploy_ether_token_test.go
+++ b/tests/ethertokentest/deploy_ether_token_test.go
@@ -26,15 +26,15 @@ func TestDeployEtherToken(t *testing.T) {
 func TestMain(m *testing.M) {
 	context = test.GetContext(big.NewInt(test.ONE_ETH * 2)) // 2 ETH in wei
 	deployed, deployedError = test.Deploy(big.NewInt(test.ONE_ETH*9), big.NewInt(test.ONE_ETH*9), context, &test.Params{
-		ConversionRate: big.NewInt(test.ONE_GWEI),
-		Spread:         big.NewInt(110),
-		ListReward:     big.NewInt(test.ONE_ETH),
-		Stake:          big.NewInt(test.ONE_GWEI),
-		VoteBy:         big.NewInt(100),
-		Quorum:         big.NewInt(50),
-		BackendPct:     big.NewInt(25),
-		MakerPct:       big.NewInt(50),
-		CostPerByte:    big.NewInt(test.ONE_KWEI * 6),
+		PriceFloor:  big.NewInt(test.ONE_GWEI),
+		Spread:      big.NewInt(110),
+		ListReward:  big.NewInt(test.ONE_ETH),
+		Stake:       big.NewInt(test.ONE_GWEI),
+		VoteBy:      big.NewInt(100),
+		Quorum:      big.NewInt(50),
+		BackendPct:  big.NewInt(25),
+		MakerPct:    big.NewInt(50),
+		CostPerByte: big.NewInt(test.ONE_KWEI * 6),
 	})
 	code := m.Run()
 	os.Exit(code)

--- a/tests/ethertokentest/deploy_ether_token_test.go
+++ b/tests/ethertokentest/deploy_ether_token_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 		ListReward:  big.NewInt(test.ONE_ETH),
 		Stake:       big.NewInt(test.ONE_GWEI),
 		VoteBy:      big.NewInt(100),
-		Quorum:      big.NewInt(50),
+		Plurality:   big.NewInt(50),
 		BackendPct:  big.NewInt(25),
 		MakerPct:    big.NewInt(50),
 		CostPerByte: big.NewInt(test.ONE_KWEI * 6),

--- a/tests/listingtest/deploy_listing_test.go
+++ b/tests/listingtest/deploy_listing_test.go
@@ -53,7 +53,7 @@ func TestMain(m *testing.M) {
 		ListReward:  big.NewInt(test.ONE_ETH),
 		Stake:       big.NewInt(test.ONE_GWEI),
 		VoteBy:      big.NewInt(100),
-		Quorum:      big.NewInt(50),
+		Plurality:   big.NewInt(50),
 		BackendPct:  big.NewInt(25),
 		MakerPct:    big.NewInt(50),
 		CostPerByte: big.NewInt(test.ONE_KWEI * 6),

--- a/tests/listingtest/deploy_listing_test.go
+++ b/tests/listingtest/deploy_listing_test.go
@@ -48,15 +48,15 @@ func TestDeployListing(t *testing.T) {
 func TestMain(m *testing.M) {
 	context = test.GetContext(big.NewInt(test.ONE_ETH * 3)) // users have 3 ETH
 	deployed, deployedError = test.Deploy(big.NewInt(test.ONE_ETH*6), big.NewInt(test.ONE_ETH*6), context, &test.Params{
-		ConversionRate: big.NewInt(test.ONE_GWEI),
-		Spread:         big.NewInt(110),
-		ListReward:     big.NewInt(test.ONE_ETH),
-		Stake:          big.NewInt(test.ONE_GWEI),
-		VoteBy:         big.NewInt(100),
-		Quorum:         big.NewInt(50),
-		BackendPct:     big.NewInt(25),
-		MakerPct:       big.NewInt(50),
-		CostPerByte:    big.NewInt(test.ONE_KWEI * 6),
+		PriceFloor:  big.NewInt(test.ONE_GWEI),
+		Spread:      big.NewInt(110),
+		ListReward:  big.NewInt(test.ONE_ETH),
+		Stake:       big.NewInt(test.ONE_GWEI),
+		VoteBy:      big.NewInt(100),
+		Quorum:      big.NewInt(50),
+		BackendPct:  big.NewInt(25),
+		MakerPct:    big.NewInt(50),
+		CostPerByte: big.NewInt(test.ONE_KWEI * 6),
 	})
 
 	// setup the datatrust with a backend

--- a/tests/markettokentest/deploy_market_token_test.go
+++ b/tests/markettokentest/deploy_market_token_test.go
@@ -31,7 +31,7 @@ func TestMain(m *testing.M) {
 		ListReward:  big.NewInt(test.ONE_ETH),
 		Stake:       big.NewInt(test.ONE_GWEI),
 		VoteBy:      big.NewInt(100),
-		Quorum:      big.NewInt(50),
+		Plurality:   big.NewInt(50),
 		BackendPct:  big.NewInt(25),
 		MakerPct:    big.NewInt(50),
 		CostPerByte: big.NewInt(test.ONE_KWEI * 6),

--- a/tests/markettokentest/deploy_market_token_test.go
+++ b/tests/markettokentest/deploy_market_token_test.go
@@ -26,15 +26,15 @@ func TestDeployMarketToken(t *testing.T) {
 func TestMain(m *testing.M) {
 	context = test.GetContext(big.NewInt(test.ONE_ETH))
 	deployed, deployedError = test.Deploy(big.NewInt(test.ONE_ETH*5), big.NewInt(test.ONE_ETH*5), context, &test.Params{
-		ConversionRate: big.NewInt(test.ONE_GWEI),
-		Spread:         big.NewInt(110),
-		ListReward:     big.NewInt(test.ONE_ETH),
-		Stake:          big.NewInt(test.ONE_GWEI),
-		VoteBy:         big.NewInt(100),
-		Quorum:         big.NewInt(50),
-		BackendPct:     big.NewInt(25),
-		MakerPct:       big.NewInt(50),
-		CostPerByte:    big.NewInt(test.ONE_KWEI * 6),
+		PriceFloor:  big.NewInt(test.ONE_GWEI),
+		Spread:      big.NewInt(110),
+		ListReward:  big.NewInt(test.ONE_ETH),
+		Stake:       big.NewInt(test.ONE_GWEI),
+		VoteBy:      big.NewInt(100),
+		Quorum:      big.NewInt(50),
+		BackendPct:  big.NewInt(25),
+		MakerPct:    big.NewInt(50),
+		CostPerByte: big.NewInt(test.ONE_KWEI * 6),
 	}) // deployed with a 5 token balance
 	code := m.Run()
 	os.Exit(code)

--- a/tests/parameterizertest/attributes_test.go
+++ b/tests/parameterizertest/attributes_test.go
@@ -14,7 +14,7 @@ func TestGetStake(t *testing.T) {
 	}
 }
 
-func TestGetConversionRate(t *testing.T) {
+func TestGetPriceFloor(t *testing.T) {
 	floor, _ := deployed.ParameterizerContract.GetPriceFloor(nil)
 
 	if floor.Cmp(big.NewInt(test.ONE_GWEI)) != 0 {

--- a/tests/parameterizertest/deploy_parameterizer_test.go
+++ b/tests/parameterizertest/deploy_parameterizer_test.go
@@ -30,7 +30,7 @@ func TestMain(m *testing.M) {
 		ListReward:  big.NewInt(test.ONE_ETH),
 		Stake:       big.NewInt(test.ONE_GWEI),
 		VoteBy:      big.NewInt(100),
-		Quorum:      big.NewInt(50),
+		Plurality:   big.NewInt(50),
 		BackendPct:  big.NewInt(25),
 		MakerPct:    big.NewInt(50),
 		CostPerByte: big.NewInt(test.ONE_KWEI * 6),

--- a/tests/parameterizertest/deploy_parameterizer_test.go
+++ b/tests/parameterizertest/deploy_parameterizer_test.go
@@ -25,15 +25,15 @@ func TestDeployParameterizer(t *testing.T) {
 func TestMain(m *testing.M) {
 	context = test.GetContext(big.NewInt(test.ONE_ETH * 5))
 	deployed, deployedError = test.Deploy(big.NewInt(test.ONE_ETH*5), big.NewInt(test.ONE_ETH*5), context, &test.Params{
-		ConversionRate: big.NewInt(test.ONE_GWEI),
-		Spread:         big.NewInt(110),
-		ListReward:     big.NewInt(test.ONE_ETH),
-		Stake:          big.NewInt(test.ONE_GWEI),
-		VoteBy:         big.NewInt(100),
-		Quorum:         big.NewInt(50),
-		BackendPct:     big.NewInt(25),
-		MakerPct:       big.NewInt(50),
-		CostPerByte:    big.NewInt(test.ONE_KWEI * 6),
+		PriceFloor:  big.NewInt(test.ONE_GWEI),
+		Spread:      big.NewInt(110),
+		ListReward:  big.NewInt(test.ONE_ETH),
+		Stake:       big.NewInt(test.ONE_GWEI),
+		VoteBy:      big.NewInt(100),
+		Quorum:      big.NewInt(50),
+		BackendPct:  big.NewInt(25),
+		MakerPct:    big.NewInt(50),
+		CostPerByte: big.NewInt(test.ONE_KWEI * 6),
 	})
 	code := m.Run()
 	os.Exit(code)

--- a/tests/reservetest/deploy_reserve_test.go
+++ b/tests/reservetest/deploy_reserve_test.go
@@ -23,15 +23,15 @@ func TestMain(m *testing.M) {
 	context = test.GetContext(big.NewInt(test.ONE_ETH * 3)) // users have 3 ETH
 	// see ./helpers#deployed
 	deployed, deployedError = test.Deploy(big.NewInt(test.ONE_ETH*6), big.NewInt(test.ONE_ETH*6), context, &test.Params{
-		ConversionRate: big.NewInt(test.ONE_GWEI),
-		Spread:         big.NewInt(110),
-		ListReward:     big.NewInt(test.ONE_ETH),
-		Stake:          big.NewInt(test.ONE_GWEI),
-		VoteBy:         big.NewInt(100),
-		Quorum:         big.NewInt(50),
-		BackendPct:     big.NewInt(25),
-		MakerPct:       big.NewInt(50),
-		CostPerByte:    big.NewInt(test.ONE_KWEI * 6),
+		PriceFloor:  big.NewInt(test.ONE_GWEI),
+		Spread:      big.NewInt(110),
+		ListReward:  big.NewInt(test.ONE_ETH),
+		Stake:       big.NewInt(test.ONE_GWEI),
+		VoteBy:      big.NewInt(100),
+		Quorum:      big.NewInt(50),
+		BackendPct:  big.NewInt(25),
+		MakerPct:    big.NewInt(50),
+		CostPerByte: big.NewInt(test.ONE_KWEI * 6),
 	})
 	code := m.Run()
 	os.Exit(code)

--- a/tests/reservetest/deploy_reserve_test.go
+++ b/tests/reservetest/deploy_reserve_test.go
@@ -28,7 +28,7 @@ func TestMain(m *testing.M) {
 		ListReward:  big.NewInt(test.ONE_ETH),
 		Stake:       big.NewInt(test.ONE_GWEI),
 		VoteBy:      big.NewInt(100),
-		Quorum:      big.NewInt(50),
+		Plurality:   big.NewInt(50),
 		BackendPct:  big.NewInt(25),
 		MakerPct:    big.NewInt(50),
 		CostPerByte: big.NewInt(test.ONE_KWEI * 6),

--- a/tests/test/deployed.go
+++ b/tests/test/deployed.go
@@ -15,15 +15,15 @@ import (
 
 // the params struct holds values that will be set in the P11r at init during deploy
 type Params struct {
-	ConversionRate *big.Int
-	Spread         *big.Int
-	ListReward     *big.Int
-	Stake          *big.Int
-	VoteBy         *big.Int
-	Quorum         *big.Int
-	BackendPct     *big.Int
-	MakerPct       *big.Int
-	CostPerByte    *big.Int
+	PriceFloor  *big.Int
+	Spread      *big.Int
+	ListReward  *big.Int
+	Stake       *big.Int
+	VoteBy      *big.Int
+	Quorum      *big.Int
+	BackendPct  *big.Int
+	MakerPct    *big.Int
+	CostPerByte *big.Int
 }
 
 // The deployed struct holds references to the instantiated contracts on the
@@ -103,7 +103,7 @@ func Deploy(etBal *big.Int, mtBal *big.Int, c *Ctx, p *Params) (*Dep, error) {
 		c.AuthOwner,
 		c.Blockchain,
 		votingAddr,
-		p.ConversionRate,
+		p.PriceFloor,
 		p.Spread,
 		p.ListReward,
 		p.Stake,

--- a/tests/test/deployed.go
+++ b/tests/test/deployed.go
@@ -20,7 +20,7 @@ type Params struct {
 	ListReward  *big.Int
 	Stake       *big.Int
 	VoteBy      *big.Int
-	Quorum      *big.Int
+	Plurality   *big.Int
 	BackendPct  *big.Int
 	MakerPct    *big.Int
 	CostPerByte *big.Int
@@ -108,7 +108,7 @@ func Deploy(etBal *big.Int, mtBal *big.Int, c *Ctx, p *Params) (*Dep, error) {
 		p.ListReward,
 		p.Stake,
 		p.VoteBy,
-		p.Quorum,
+		p.Plurality,
 		p.BackendPct,
 		p.MakerPct,
 		p.CostPerByte,

--- a/tests/votingtest/deploy_voting_test.go
+++ b/tests/votingtest/deploy_voting_test.go
@@ -50,7 +50,7 @@ func TestMain(m *testing.M) {
 		ListReward:  big.NewInt(test.ONE_ETH),
 		Stake:       big.NewInt(test.ONE_GWEI),
 		VoteBy:      big.NewInt(100),
-		Quorum:      big.NewInt(50),
+		Plurality:   big.NewInt(50),
 		BackendPct:  big.NewInt(25),
 		MakerPct:    big.NewInt(50),
 		CostPerByte: big.NewInt(test.ONE_KWEI * 6),

--- a/tests/votingtest/deploy_voting_test.go
+++ b/tests/votingtest/deploy_voting_test.go
@@ -45,15 +45,15 @@ func TestSetPrivileged(t *testing.T) {
 func TestMain(m *testing.M) {
 	context = test.GetContext(big.NewInt(test.ONE_ETH))
 	deployed, deployedError = test.Deploy(big.NewInt(test.ONE_ETH*5), big.NewInt(test.ONE_ETH*5), context, &test.Params{
-		ConversionRate: big.NewInt(test.ONE_GWEI),
-		Spread:         big.NewInt(110),
-		ListReward:     big.NewInt(test.ONE_ETH),
-		Stake:          big.NewInt(test.ONE_GWEI),
-		VoteBy:         big.NewInt(100),
-		Quorum:         big.NewInt(50),
-		BackendPct:     big.NewInt(25),
-		MakerPct:       big.NewInt(50),
-		CostPerByte:    big.NewInt(test.ONE_KWEI * 6),
+		PriceFloor:  big.NewInt(test.ONE_GWEI),
+		Spread:      big.NewInt(110),
+		ListReward:  big.NewInt(test.ONE_ETH),
+		Stake:       big.NewInt(test.ONE_GWEI),
+		VoteBy:      big.NewInt(100),
+		Quorum:      big.NewInt(50),
+		BackendPct:  big.NewInt(25),
+		MakerPct:    big.NewInt(50),
+		CostPerByte: big.NewInt(test.ONE_KWEI * 6),
 	})
 	code := m.Run()
 	os.Exit(code)


### PR DESCRIPTION
This PR adds a test for the scenario where the creator block size is set to 0 and no direct transfer of ETH happens. The test verifies that the behavior of the protocol is reasonable. The printouts from the test allow for visual inspection that the curve behaves reasonably.

This PR also includes a second changes swapping the old `ConversionRate` terminology to the new `PriceFloor` terminology throughout the tests.